### PR TITLE
Add `IRenderer.set_push_constants`

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -32,6 +32,8 @@ void run() {
 	auto const audio_buffer = asset_loader.load<le::IAudioBuffer>("audio/explode.wav");
 	if (!audio_buffer) { throw std::runtime_error{"Failed to load Audio Buffer."}; }
 
+    
+
 	// the waiter blocks on destruction until the context is idle,
 	// after which the loaded resources can be safely destroyed.
 	auto const waiter = context->create_waiter();

--- a/lib/include/le2d/push_constant.hpp
+++ b/lib/include/le2d/push_constant.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace le {
+struct PushConstant {
+	vk::ShaderStageFlagBits stages{};
+	std::uint32_t size{};
+	std::array<std::byte, 128> data{};
+	std::uint32_t offset{};
+};
+} // namespace le

--- a/lib/include/le2d/renderer.hpp
+++ b/lib/include/le2d/renderer.hpp
@@ -39,6 +39,7 @@ class IRenderer : public klib::Polymorphic {
 	virtual void set_line_width(float width) = 0;
 	virtual void set_shader(IShader const& shader) = 0;
 	virtual void set_user_data(UserDrawData const& user_data) = 0;
+	virtual void set_push_constants(vk::ShaderStageFlagBits stages, std::uint32_t size, void const* data, std::uint32_t offset = 0) = 0;
 
 	/// \brief Draw given instances of a Primitive.
 	/// \param primitive Primitive to draw.

--- a/lib/src/detail/pipeline_pool.hpp
+++ b/lib/src/detail/pipeline_pool.hpp
@@ -82,8 +82,14 @@ class PipelinePool {
 	}
 
 	void create_layout() {
+		auto const max_push_constant_size = m_render_device->get_gpu().properties.limits.maxPushConstantsSize;
+
+		auto const push_constant_range =
+			vk::PushConstantRange{}.setStageFlags(vk::ShaderStageFlagBits::eAllGraphics).setOffset(0).setSize(max_push_constant_size);
+
 		auto plci = vk::PipelineLayoutCreateInfo{};
 		plci.setSetLayouts(m_set_layouts);
+		plci.setPushConstantRanges(push_constant_range);
 		m_layout = m_render_device->get_device().createPipelineLayoutUnique(plci);
 	}
 

--- a/lib/src/detail/renderer.cpp
+++ b/lib/src/detail/renderer.cpp
@@ -115,6 +115,8 @@ void Renderer::draw(Primitive const& primitive, std::span<RenderInstance const> 
 	cmd.setViewport(0, m_viewport);
 	cmd.setScissor(0, m_scissor);
 	cmd.setLineWidth(m_line_width);
+	cmd.pushConstants(m_resource_pool->get_pipeline_layout(), m_push_constants.stages, m_push_constants.offset, m_push_constants.size,
+					  m_push_constants.data.data());
 
 	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_resource_pool->get_pipeline_layout(), 0, descriptor_sets, {});
 	vbo.draw(cmd, std::uint32_t(instances.size()));

--- a/lib/src/detail/renderer.hpp
+++ b/lib/src/detail/renderer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "le2d/push_constant.hpp"
 #include "le2d/renderer.hpp"
 #include <detail/resource/resource_pool.hpp>
 #include <kvf/render_device.hpp>
@@ -34,6 +35,10 @@ class Renderer : public IRenderer {
 
 	void set_shader(IShader const& shader) final { m_shader = &shader; }
 	void set_user_data(UserDrawData const& user_data) final { m_user_data = user_data; }
+	void set_push_constants(vk::ShaderStageFlagBits stages, std::uint32_t size, void const* data, std::uint32_t offset) final {
+		m_push_constants = {.stages = stages, .size = size, .offset = offset};
+		if (data && size > 0) { std::memcpy(m_push_constants.data.data(), data, size); }
+	}
 
 	[[nodiscard]] auto framebuffer_size() const -> glm::ivec2 final { return kvf::util::to_glm_vec<int>(m_pass->get_extent()); }
 
@@ -57,6 +62,8 @@ class Renderer : public IRenderer {
 
 	vk::Pipeline m_pipeline{};
 	float m_line_width{1.0f};
+
+	PushConstant m_push_constants{};
 
 	kvf::RenderTarget m_rt{};
 	RenderStats m_stats{};


### PR DESCRIPTION
Add `PushConstant` and it's method for applying it to the command buffer

Usage example:
`renderer.set_push_constants(vk::ShaderStageFlagBits::eFragment, sizeof(glm::vec4), &test_vec);`